### PR TITLE
Set charset using meta tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
   xml:lang="ja">
   <head>
     <title>{{ site.title }}{% if page.title %} | {{ page.title }}{% endif %}</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <meta name="description" content="札幌にて Ruby に関する活動を行っているコミュニティです。Ruby勉強会＠札幌 や 開発集会@札幌、Ruby Sapporo Night などのイベントを定期的に開催しています。" />
     <meta name="keywords" content="Ruby 札幌 Rails 勉強会 Ruby Sapporo Night ユーザ会 コミュニティ 開発集会" />
     <link href="/rss" rel="alternate" title="RSS" type="application/rss+xml" />


### PR DESCRIPTION
meta タグで `charset` を指定するようにしました。
この指定を行わない状態だと、 IE で文字化けが発生していました。
