### PR TITLE
サイドバーのコミュニケーションのところを整理する

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -23,6 +23,7 @@
 
 <ul>
 <li><a href='http://qwik.jp/RubySapporo/'>メーリングリスト/Wiki</a></li>
+<li>Idobata <a href='https://idobata.io/organizations/ruby-sapporo/rooms/talk/join_request/4d16ea48-e8bd-4f87-866e-6673fb9ea468'>Ruby Sapporo</a></li>
 </ul>
 
 <h2 id='id5'>最近のニュース</h2>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -23,10 +23,6 @@
 
 <ul>
 <li><a href='http://qwik.jp/RubySapporo/'>メーリングリスト/Wiki</a></li>
-
-<li>irc <a href='http://webchat.freenode.net/?channels=RubySapporo'>#RubySapporo on irc.freenode.net</a></li>
-
-<li>Lingr <a href='http://lingr.com/room/rubysapporo'>Ruby札幌オープンチャット</a></li>
 </ul>
 
 <h2 id='id5'>最近のニュース</h2>


### PR DESCRIPTION
初めてくる人が活発じゃないところに行くと可哀想なのでサイドバーのコミュニケーションのところを整理したらいいんじゃないかなと考えています．

やるとしたらこんな感じ？

| 種類 | どうする？ |
| --- | --- |
| メーリングリスト/Wiki | 残す |
| IRC | どうしましょう？ |
| Lingr | はずす(447日前から更新されていないようなので) |
| idobata.io | 足す |
